### PR TITLE
Potential fix for code scanning alert no. 9: Prototype-polluting assignment

### DIFF
--- a/backend/routes/roomRoutes.js
+++ b/backend/routes/roomRoutes.js
@@ -30,6 +30,9 @@ router.post("/join", async (req, res) => {
 // @route POST /api/room/start
 router.post("/start", async (req, res) => {
     const { roomCode } = req.body;
+    if (roomCode === '__proto__' || roomCode === 'constructor' || roomCode === 'prototype') {
+      return res.status(400).json({ message: "Invalid room code" });
+    }
   
     try {
       const room = await roomService.startGame(roomCode);

--- a/backend/services/room/roomService.js
+++ b/backend/services/room/roomService.js
@@ -34,6 +34,9 @@ exports.getRoom = async (roomCode) => {
 };
 
 exports.startGame = async (roomCode) => {
+  if (roomCode === '__proto__' || roomCode === 'constructor' || roomCode === 'prototype') {
+    throw new Error("Invalid room code");
+  }
   const room = rooms[roomCode];
   if (!room) throw new Error("Room not found");
   if (room.gameStarted) throw new Error("Game already started");


### PR DESCRIPTION
Potential fix for [https://github.com/davhsi/fruit-ninja-game/security/code-scanning/9](https://github.com/davhsi/fruit-ninja-game/security/code-scanning/9)

To fix the issue, we need to prevent prototype pollution by ensuring that user-controlled input (`roomCode`) cannot be used to modify `Object.prototype`. This can be achieved by validating `roomCode` before using it as a key in the `rooms` object. Specifically, we can reject `roomCode` values that are `__proto__`, `constructor`, or `prototype`. This approach is simple, effective, and does not require changes to the structure of the `rooms` object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
