### PR TITLE
Potential fix for code scanning alert no. 8: Clear-text logging of sensitive information

### DIFF
--- a/backend/utils/jwtUtils.js
+++ b/backend/utils/jwtUtils.js
@@ -3,7 +3,7 @@ const jwt = require("jsonwebtoken");
 require("dotenv").config();
 const JWT_SECRET = process.env.JWT_SECRET;
 
-console.log("🧪 jwtUtils: JWT_SECRET =", process.env.JWT_SECRET);
+// Removed logging of JWT_SECRET to prevent exposure of sensitive information.
 
 exports.signToken = (payload) => jwt.sign(payload, JWT_SECRET, { expiresIn: "7d" });
 


### PR DESCRIPTION
Potential fix for [https://github.com/davhsi/fruit-ninja-game/security/code-scanning/8](https://github.com/davhsi/fruit-ninja-game/security/code-scanning/8)

To fix the issue, the logging of sensitive information should be removed entirely or replaced with a safer alternative that does not expose the sensitive value. If logging is necessary for debugging purposes, it should be conditionally enabled only in non-production environments.

The best approach is to remove the logging of `process.env.JWT_SECRET` entirely, as it is not essential for the application's functionality. If debugging is required, a generic message indicating the presence of the secret can be logged without revealing its value.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
