### PR TITLE
Potential fix for code scanning alert no. 6: Use of externally-controlled format string

### DIFF
--- a/backend/websocket/wsHandlers/leaderboard.js
+++ b/backend/websocket/wsHandlers/leaderboard.js
@@ -34,7 +34,7 @@ async function broadcastLeaderboard(roomCode) {
     payload: leaderboard,
   });
 
-  console.log(`📊 Final Leaderboard Payload for ${roomCode}:`, leaderboard);
+  console.log("📊 Final Leaderboard Payload for %s:", roomCode, leaderboard);
 }
 
 module.exports = broadcastLeaderboard;


### PR DESCRIPTION
Potential fix for [https://github.com/davhsi/fruit-ninja-game/security/code-scanning/6](https://github.com/davhsi/fruit-ninja-game/security/code-scanning/6)

To fix the issue, the untrusted `roomCode` value should be sanitized or safely included in the format string using a `%s` specifier. This ensures that the value is treated as a string and prevents any unintended format specifiers from being processed. The fix involves modifying the logging statement on line 37 in `broadcastLeaderboard` to use a `%s` specifier and pass `roomCode` as a separate argument.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
